### PR TITLE
Ignore regions that aren't configured selecting an s3 region to download from

### DIFF
--- a/api/src/tooltool_api/api.py
+++ b/api/src/tooltool_api/api.py
@@ -279,9 +279,11 @@ def download_file(digest: str) -> werkzeug.Response:
         regions = ", ".join(s3_regions.keys())
         logger2.debug(f"Looking for file in following regions: {regions}")
 
-        # preferred region not found, so pick one from the available set
-        selected_region = random.choice([inst.region for inst in file_row.instances])
+        available_regions = set(s3_regions).intersection(set([inst.region for inst in file_row.instances]))
+        if not available_regions:
+            raise werkzeug.exceptions.InternalServerError(f"No available regions for file")
 
+        selected_region = random.choice(list(available_regions))
         bucket = s3_regions.get(selected_region)
         if bucket is None:
             raise werkzeug.exceptions.InternalServerError(f"Region `{selected_region}` can not be found in S3_REGIONS.")

--- a/api/src/tooltool_api/api.py
+++ b/api/src/tooltool_api/api.py
@@ -281,7 +281,7 @@ def download_file(digest: str) -> werkzeug.Response:
 
         available_regions = set(s3_regions).intersection(set([inst.region for inst in file_row.instances]))
         if not available_regions:
-            raise werkzeug.exceptions.InternalServerError(f"No available regions for file")
+            raise werkzeug.exceptions.InternalServerError("No available regions for file")
 
         selected_region = random.choice(list(available_regions))
         bucket = s3_regions.get(selected_region)


### PR DESCRIPTION
At the moment, tooltool assumes that any region mentioned in a file row has a bucket configured and available. This has been true up until today, when we tried to migrate to a single S3 bucket owned by CloudOps. When tooltool was deployed with only usw2 configured, about 1/3 of the requests failed.

This code is likely to die when we enable Cloudfront, but in case we end up deploying without it again, we ought to take this simple fix.