### PR TITLE
Report ERROR logs to sentry

### DIFF
--- a/api/src/tooltool_api/lib/log.py
+++ b/api/src/tooltool_api/lib/log.py
@@ -57,7 +57,7 @@ def setup_sentry(project_name, env, SENTRY_DSN, flask_app=None):
 
         raven.contrib.flask.Sentry(flask_app, client=sentry_client)
 
-    sentry_handler = raven.handlers.logbook.SentryHandler(sentry_client, level=logbook.WARNING, bubble=True)
+    sentry_handler = raven.handlers.logbook.SentryHandler(sentry_client, level=logbook.ERROR, bubble=True)
     sentry_handler.push_application()
 
 


### PR DESCRIPTION
Apparently Sentry is configured to get WARNING logging. Let's tune it down to the default ERROR level.