### PR TITLE
allow using env taskcluster auth

### DIFF
--- a/client/tooltool.py
+++ b/client/tooltool.py
@@ -1120,25 +1120,36 @@ def _log_api_error(e):
 
 
 def _authorize(req, auth_file):
-    if not auth_file:
-        return
-
     is_taskcluster_auth = False
-    with open(auth_file) as f:
-        auth_file_content = f.read().strip()
+
+    if not auth_file:
         try:
-            auth_file_content = json.loads(auth_file_content)
+            taskcluster_env_keys = {
+                'clientId': 'TASKCLUSTER_CLIENT_ID',
+                'accessToken': 'TASKCLUSTER_ACCESS_TOKEN',
+            }
+            auth_content = {
+                k: os.environ[v] for k, v in taskcluster_env_keys.items()
+            }
             is_taskcluster_auth = True
-        except Exception:
-            pass
+        except KeyError:
+            return
+    else:
+        with open(auth_file) as f:
+            auth_content = f.read().strip()
+            try:
+                auth_content = json.loads(auth_content)
+                is_taskcluster_auth = True
+            except Exception:
+                pass
 
     if is_taskcluster_auth:
-        taskcluster_header = make_taskcluster_header(auth_file_content, req)
+        taskcluster_header = make_taskcluster_header(auth_content, req)
         log.debug("Using taskcluster credentials in %s" % auth_file)
         req.add_unredirected_header('Authorization', taskcluster_header)
     else:
         log.debug("Using Bearer token in %s" % auth_file)
-        req.add_unredirected_header('Authorization', 'Bearer %s' % auth_file_content)
+        req.add_unredirected_header('Authorization', 'Bearer %s' % auth_content)
 
 
 def _send_batch(base_url, auth_file, batch, region):


### PR DESCRIPTION
This change allows getting the credentials from the taskcluster environment variables if the authentication-file argument is not set:
```
$ python tooltool.py add --visibility public image001.png 
$ python tooltool.py upload --url=https://stage.tooltool.mozilla-releng.net/ --message 'test upload to stage'
ERROR - 403 Forbidden: no permission to upload public files: no permission to upload public files
$ set|grep TASKCLUSTER
$ eval $(taskcluster signin)
INFO Starting                                     
INFO Listening for a callback on: http://localhost:35659 
INFO Opening URL: https://firefox-ci-tc.services.mozilla.com/auth/clients/create?scope=%2A&name=cli-OGsohB&expires=1d&callback_url=http%3A%2F%2Flocalhost%3A35659&description=Temporary+client+for+use+on+the+command+line 
INFO Credentials output as environment variables  
$ python tooltool.py upload --url=https://stage.tooltool.mozilla-releng.net/ --message 'test upload to stage'
INFO - image001.png: starting upload
INFO - image001.png: uploaded
INFO - notifying server of upload completion for image001.png
WARNING - Waiting 59 seconds for upload URLs to expire
$ cat manifest.tt
[
  {
    "filename": "image001.png",
    "size": 346908,
    "algorithm": "sha512",
    "digest": "75683fd61011d86eb2fbdcb0f310410af5c4b4c8bc673195b53f11276fd72f9d03cd0cd44c1e18a209bbce49a3eb79be7e16832d7ec47279e5be28793a1b7620",
    "visibility": "public"
  }
```