### PR TITLE
client: don't read the whole file in memory before upload

### DIFF
--- a/client/test_tooltool.py
+++ b/client/test_tooltool.py
@@ -932,7 +932,7 @@ class UploadTests(TestDirMixin, unittest.TestCase):
 
     def test_s3_upload(self):
         self.start_server()
-        file = {'put_url': self.s3url('/sha512/' + self.digest)}
+        file = {'put_url': self.s3url('/sha512/' + self.digest), 'size': len(self.content)}
         tooltool._s3_upload('testfile.txt', file)
         eq_(self.server_requests, {'PUT': [self.digest]})
         assert file['upload_ok']
@@ -940,7 +940,7 @@ class UploadTests(TestDirMixin, unittest.TestCase):
     def test_s3_upload_fails(self):
         self.start_server()
         self.server_config['upload_failures'] = [self.digest]
-        file = {'put_url': self.s3url('/sha512/' + self.digest)}
+        file = {'put_url': self.s3url('/sha512/' + self.digest), 'size': len(self.content)}
         tooltool._s3_upload('testfile.txt', file)
         eq_(self.server_requests, {'PUT': [self.digest]})
         assert not file['upload_ok'], file

--- a/client/tooltool.py
+++ b/client/tooltool.py
@@ -1316,9 +1316,7 @@ def _s3_upload(filename, file):
     try:
         req_path = "%s?%s" % (url.path, url.query) if url.query else url.path
         with open(filename, "rb") as f:
-            content = f.read()
-            content_length = len(content)
-            f.seek(0)
+            content_length = file["size"]
             conn.request(
                 "PUT",
                 req_path,


### PR DESCRIPTION
We were reading the file just to figure out its size, which is quite wasteful especially if it's big.  Turns out we already know the size, it's in the manifest (and we've validated it against the actual file).