### PR TITLE
Fix error handling regression from connexion upgrade

### DIFF
--- a/api/src/tooltool_api/lib/api.py
+++ b/api/src/tooltool_api/lib/api.py
@@ -28,16 +28,6 @@ class Api:
         """
         self.__app = app
 
-        logger.debug("Setting JSON encoder.")
-        app.json_encoder = FlaskJSONEncoder
-
-        logger.debug("Setting common error handler for all error codes.")
-        # FlaskApp sets up error handler automatically, but FlaskApi doesn't.
-        # We have to set them up manually.
-        for error_code in default_exceptions:
-            app.register_error_handler(error_code, FlaskApp.common_error_handler)
-
-        app.register_error_handler(ProblemException, FlaskApp.common_error_handler)
 
     def register(
         self,

--- a/api/src/tooltool_api/lib/flask.py
+++ b/api/src/tooltool_api/lib/flask.py
@@ -6,6 +6,7 @@
 import importlib
 import os
 
+import connexion
 import flask
 
 import tooltool_api.lib.dockerflow
@@ -24,7 +25,8 @@ def create_app(project_name, extensions=[], config=None, enable_dockerflow=True,
     """
     logger.debug("Initializing", app=project_name)
 
-    app = flask.Flask(import_name=project_name, **kw)
+    connexion_app = connexion.FlaskApp(import_name=project_name, server_args=kw)
+    app = connexion_app.app
     app.name = project_name
     app.__extensions = extensions
 


### PR DESCRIPTION
https://github.com/spec-first/connexion/pull/1326 changed FlaskApp.common_error_handler from a static method to a regular method, which means we can't use it without an actual FlaskApp, or we'd turn any error into a TypeError and 500.

Fixes #1159