### PR TITLE
ci: switch to taskgraph

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,223 +1,295 @@
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# yamllint disable rule:line-length
+# This file is rendered via JSON-e by
+# - github events - https://github.com/taskcluster/taskcluster/tree/main/services/github
+# - cron tasks - https://hg.mozilla.org/ci/ci-admin/file/default/build-decision/
+# - action tasks - taskcluster/taskgraph/actions/registry.py
+---
 version: 1
+reporting: checks-v1
+autoCancelPreviousChecks: true
 policy:
-  pullRequests: public
+    pullRequests: public
 tasks:
-  $let:
-    # -------------------------------------------------------------------------
-    # -- This is where you add new projects -----------------------------------
-    # -------------------------------------------------------------------------
-    PROJECTS:
-      $let:
-        client_setup_3: 'apt-get update && apt-get install -y zip xz-utils build-essential libssl-dev libffi-dev python3-dev &&'
-        api_setup: 'apt-get update && apt-get install -y postgresql &&'
+    - $let:
+          trustDomain: "releng"
+          ownerEmail:
+              $switch:
+                  'tasks_for == "github-push"': '${event.pusher.email}'
+                  'tasks_for == "github-release"': '${event.sender.login}@users.noreply.github.com'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.user.login}@users.noreply.github.com'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${tasks_for}@noreply.mozilla.org'
+          baseRepoUrl:
+              $switch:
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.repo.html_url}'
+                  'tasks_for in ["cron", "action"]': '${repository.url}'
+                  'tasks_for == "pr-action"': '${repository.base_url}'
+                  $default: '${event.repository.html_url}'
+          repoUrl:
+              $switch:
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.html_url}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${repository.url}'
+                  $default: '${event.repository.html_url}'
+          project:
+              $switch:
+                  'tasks_for in ["github-push", "github-release"]': '${event.repository.name}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.repo.name}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${repository.project}'
+          head_branch:
+              $switch:
+                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
+                  'tasks_for == "github-push"': ${event.ref}
+                  'tasks_for == "github-release"': '${event.release.target_commitish}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
+          base_ref:
+              $switch:
+                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.base.ref}
+                  'tasks_for == "github-push" && event.base_ref': ${event.base_ref}
+                  'tasks_for == "github-push" && !(event.base_ref)': ${event.ref}
+                  'tasks_for == "github-release"': ''
+                  'tasks_for in ["cron", "action"]': '${push.branch}'
+                  'tasks_for == "pr-action"': '${push.base_branch}'
+          head_ref:
+              $switch:
+                  'tasks_for[:19] == "github-pull-request"': ${event.pull_request.head.ref}
+                  'tasks_for == "github-push"': ${event.ref}
+                  'tasks_for == "github-release"': ${event.release.tag_name}
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.branch}'
+          base_sha:
+              $switch:
+                  'tasks_for == "github-push"': '${event.before}'
+                  'tasks_for == "github-release"': '${event.release.target_commitish}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.base.sha}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
+          head_sha:
+              $switch:
+                  'tasks_for == "github-push"': '${event.after}'
+                  'tasks_for == "github-release"': '${event.release.tag_name}'
+                  'tasks_for[:19] == "github-pull-request"': '${event.pull_request.head.sha}'
+                  'tasks_for in ["cron", "action", "pr-action"]': '${push.revision}'
+          ownTaskId:
+              $switch:
+                  '"github" in tasks_for': {$eval: as_slugid("decision_task")}
+                  'tasks_for in ["cron", "action", "pr-action"]': '${ownTaskId}'
+          pullRequestAction:
+              $switch:
+                  'tasks_for[:19] == "github-pull-request"': ${event.action}
+                  $default: 'UNDEFINED'
+          releaseAction:
+              $if: 'tasks_for == "github-release"'
+              then: ${event.action}
+              else: 'UNDEFINED'
+          isPullRequest:
+              $eval: 'tasks_for[:19] == "github-pull-request"'
       in:
-        # [ <PROJECT NAME>,   <PYTHON VERSION>, <SETUP COMMAND>,     <DOCKERHUB REPO>]
-        - ['tooltool_client', '38',             '${client_setup_3}', '']
-        - ['tooltool_client', '39',             '${client_setup_3}', '']
-        - ['tooltool_client', '310',            '${client_setup_3}', '']
-        - ['tooltool_client', '311',            '${client_setup_3}', '']
-        - ['tooltool_client', '312',            '${client_setup_3}', '']
-        - ['tooltool_api',    '38',             '${api_setup}',      'mozilla/releng-tooltool']
-        - ['tooltool_api',    '39',             '${api_setup}',      '']
-        - ['tooltool_api',    '310',            '${api_setup}',      '']
-        - ['tooltool_api',    '311',            '${api_setup}',      '']
-    # -------------------------------------------------------------------------
+          $let:
+              short_base_ref:
+                  $switch:
+                      'base_ref[:10] == "refs/tags/"': '${base_ref[10:]}'
+                      'base_ref[:11] == "refs/heads/"': '${base_ref[11:]}'
+                      $default: '${base_ref}'
+              short_head_ref:
+                  $switch:
+                      'head_ref[:10] == "refs/tags/"': '${head_ref[10:]}'
+                      'head_ref[:11] == "refs/heads/"': '${head_ref[11:]}'
+                      $default: '${head_ref}'
+              level:
+                  $if: 'isPullRequest || tasks_for == "pr-action"'
+                  then: "1"
+                  else: "3"
+          in:
+              $if: >
+                  tasks_for in ["action", "pr-action", "cron"]
+                  || (tasks_for == "github-push" && short_head_ref == "main")
+                  || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
+              then:
+                  taskId: {$if: 'tasks_for != "action" && tasks_for != "pr-action"', then: '${ownTaskId}'}
+                  taskGroupId:
+                      $if: 'tasks_for in ["action", "pr-action"]'
+                      then:
+                          '${action.taskGroupId}'
+                      else:
+                          '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
+                  schedulerId: '${trustDomain}-level-${level}'
+                  created: {$fromNow: ''}
+                  deadline: {$fromNow: '1 day'}
+                  expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first
+                  metadata:
+                      $merge:
+                          - owner: "${ownerEmail}"
+                            source: "${repoUrl}/raw/${head_sha}/.taskcluster.yml"
+                          - $switch:
+                                'tasks_for == "github-push" || isPullRequest':
+                                    name: "Decision Task"
+                                    description: 'The task that creates all of the other tasks in the task graph'
+                                'tasks_for == "action"':
+                                    name: "Action: ${action.title}"
+                                    description: |
+                                        ${action.description}
 
-    HEAD_REV:
-      $if: 'tasks_for == "github-pull-request"'
-      then: '${event.pull_request.head.sha}'
-      else:
-        $if: 'tasks_for == "github-push"'
-        then: '${event.after}'
-        else: '${event.release.tag_name}'
+                                        Action triggered by clientID `${clientId}`
+                                'tasks_for == "pr-action"':
+                                    name: "PR action: ${action.title}"
+                                    description: |
+                                        ${action.description}
 
-    REPO_URL:
-      $if: 'tasks_for == "github-pull-request"'
-      then: '${event.pull_request.head.repo.html_url}'
-      else: '${event.repository.html_url}'
+                                        PR action triggered by clientID `${clientId}`
+                                $default:
+                                    name: "Decision Task for cron job ${cron.job_name}"
+                                    description: 'Created by a [cron task](https://firefox-ci-tc.services.mozilla.com/tasks/${cron.task_id})'
 
-    OWNER: '${event.sender.login}@users.noreply.github.com'
+                  provisionerId: "${trustDomain}-${level}"
+                  workerType: "decision-gcp"
 
-    BRANCH_NAME:
-      $if: 'tasks_for == "github-pull-request"'
-      then: 'pull-request'
-      else:
-        $if: 'tasks_for == "github-push" && event.ref[0:11] == "refs/heads/"'
-        then: '${event.ref[11:]}'
-        else: 'unknown'
-  in:
-    $flatten:
-      $map: { "$eval": "PROJECTS" }
-      each(x,i):
-        $let:
-          project_name: { "$eval": "x[0]" }
-          python_version: { "$eval": "x[1]" }
-          setup_command: { "$eval": "x[2]" }
-          dockerhub_repo: { "$eval": "x[3]" }
-          run_tests:
-            $if: 'tasks_for == "github-pull-request"'
-            then: '1'
-            else:
-              $if: 'tasks_for == "github-push" && event.ref in ["refs/heads/master","refs/heads/staging","refs/heads/production","refs/heads/staging-" + x[0],"refs/heads/production-" + x[0]]'
-              then: '1'
-              else: '0'
-          push_docker_image:
-            $if: 'tasks_for == "github-pull-request"'
-            then: '0'
-            else:
-              $if: 'tasks_for == "github-push" && event.ref in ["refs/heads/staging","refs/heads/production","refs/heads/staging-" + x[0],"refs/heads/production-" + x[0]]'
-              then: '1'
-              else: '0'
-          worker_level:
-            $if: 'tasks_for == "github-pull-request"'
-            then: 't'
-            else:
-              $if: 'tasks_for == "github-push" && event.ref in ["refs/heads/production","refs/heads/production-" + x[0]]'
-              then: '3'
-              else: 't'
-          number_prefix: ''
-          docker_tag:
-            $if: 'tasks_for == "github-pull-request"'
-            then: 'pull-request'
-            else:
-              $if: 'tasks_for == "github-push" && event.ref in ["refs/heads/staging-" + x[0],"refs/heads/production-" + x[0]]'
-              then: '${event.ref[11:-(len(x[0]) + 1)]}'
-              else:
-                $if: 'tasks_for == "github-push" && event.ref[0:11] == "refs/heads/"'
-                then: '${event.ref[11:]}'
-                else: 'unknown'
-          frontend_config:
-            $if: 'tasks_for == "github-push"'
-            then:
-              $if: 'event.ref[0:18] == "refs/heads/staging"'
-              then: 'config.stage.mjs'
-              else:
-                $if: 'event.ref[0:21] == "refs/heads/production"'
-                then: 'config.prod.mjs'
-                else: 'config.local.mjs'
-            else: 'config.local.mjs'
-        in:
-          $match:
-            # Run code linting and unit tests for each project 
-            'run_tests == "1"':
-              taskId: '${as_slugid(project_name + python_version)}'
-              provisionerId: 'releng-t'
-              workerType: 'linux-gcp'
-              created: { $fromNow: '' }
-              deadline: { $fromNow: '4 hours' }
-              payload:
-                features:
-                  taskclusterProxy: true
-                maxRunTime: 3600
-                image: 'python:${python_version[0]}.${python_version[1:]}'
-                env:
-                  CI_HEAD_REV: '${HEAD_REV}'
-                  CI_BRANCH_NAME:
-                    $if: 'tasks_for == "github-push"'
-                    then: '${event.ref[11:]}'
-                    else: ''
-                  CI_PR_NUMBER:
-                    $if: 'tasks_for == "github-pull-request"'
-                    then: '${event.pull_request.number}'
-                    else: ''
-                  SECRET_URL: 'http://taskcluster/secrets/v1/secret/project/releng/tooltool/ci'
-                command:
-                  - sh
-                  - -lxce
-                  - >-
-                    groupadd --gid 10001 app &&
-                    useradd -g app --uid 10001 --shell /bin/bash --create-home --home-dir /src app && ${setup_command}
-                    apt-get update && apt-get install -y jq &&
-                    set +o xtrace &&
-                    export CODECOV_TOKEN=$(wget -qO- $SECRET_URL | jq -r '.["secret"]["codecov"]["token"]') &&
-                    set -o xtrace &&
-                    su app -c "
-                      cd /tmp &&
-                      wget ${REPO_URL}/archive/${HEAD_REV}.tar.gz &&
-                      tar zxf ${HEAD_REV}.tar.gz &&
-                      mv tooltool-${HEAD_REV}/* /src/ &&
-                      cd /src &&
-                      pip install --user tox --no-warn-script-location &&
-                      /src/.local/bin/tox -e ${project_name}-py${python_version}
-                      "
-              scopes:
-                - 'secrets:get:project/releng/tooltool/ci'
-              metadata:
-                name:
-                  $let:
-                    test_task_number:
-                      $if: 'dockerhub_repo != ""'
-                      then: '${i+1}.1'
-                      else: '${i+1}'
-                  in:
-                    '${number_prefix}${test_task_number}. ${project_name}-py${python_version}: Run tox [on ${BRANCH_NAME}]'
-                description: 'Code linting and unit tests for ${project_name} on python ${python_version[0]}.${python_version[1:]}'
-                owner: '${OWNER}'
-                source: '${REPO_URL}/raw/${HEAD_REV}/.taskcluster.yml'
-            # Build docker image and (optionally) push to docker hub
-            'run_tests == "1" && dockerhub_repo != ""':
-              taskId: '${as_slugid(project_name + "docker_build_and_push")}'
-              dependencies:
-                - '${as_slugid(project_name + python_version)}'
-              provisionerId: 'releng-${worker_level}'
-              workerType: 'linux-gcp'
-              created: { $fromNow: '' }
-              deadline: { $fromNow: '24 hours' }
-              payload:
-                features:
-                  dind: true
-                  taskclusterProxy: true
-                maxRunTime: 3600
-                # we need to run really old docker version because taskcluster is using
-                # really old version in their setup
-                # image: docker:stable
-                image: 'docker:1.6.2'
-                env:
-                  DOCKERHUB_EMAIL: 'release+dockerhub+services@mozilla.com'
-                  DOCKERHUB_USER: 'mozillarelengservices'
-                  DOCKER_REPO: '${dockerhub_repo}'
-                  DOCKER_TAG: '${docker_tag}'
-                  FRONTEND_CONFIG: '${frontend_config}'
-                  GIT_HEAD_REV: '${HEAD_REV}'
-                  PROJECT_NAME: '${project_name}'
-                  PUSH_DOCKER_IMAGE: '${push_docker_image}'
-                  REPO_URL: '${REPO_URL}'
-                  SECRET_URL: 'http://taskcluster/secrets/v1/secret/project/releng/tooltool/deploy'
-                command:
-                  - sh
-                  - -lxce
-                  - >-
-                    cd /tmp &&
-                    wget ${REPO_URL}/archive/${HEAD_REV}.tar.gz &&
-                    tar zxf ${HEAD_REV}.tar.gz &&
-                    mv tooltool-${HEAD_REV} /src &&
-                    cd /src/${project_name[9:]} &&
-                    ./docker.d/generate_version_json.sh &&
-                    ./docker.d/build_image.sh /tmp/image.tar &&
-                    if [ "$PUSH_DOCKER_IMAGE" == "1" ]; then
-                      ./docker.d/push_image.sh
-                    fi
-                artifacts:
-                  public/image.tar:
-                    expires: {$fromNow: '8 weeks'}
-                    path: '/tmp/image.tar'
-                    type: 'file'
-              scopes:
-                $if: 'push_docker_image == "0"'
-                then: []
-                else:
-                  - 'secrets:get:project/releng/tooltool/deploy'
-              metadata:
-                $let:
-                  description:
-                    $if: 'push_docker_image == "0"'
-                    then: '${project_name}-py${python_version}: Build docker image [on ${BRANCH_NAME}]'
-                    else: '${project_name}-py${python_version}: Build and push docker image [on ${BRANCH_NAME}]'
-                in:
-                  name: '${number_prefix}${i+1}.2. ${description}'
-                  description: '${description}'
-                  owner: '${OWNER}'
-                  source: '${REPO_URL}/raw/${HEAD_REV}/.taskcluster.yml'
+                  tags:
+                      $switch:
+                          'tasks_for == "github-push" || isPullRequest':
+                              createdForUser: "${ownerEmail}"
+                              kind: decision-task
+                          'tasks_for in ["action", "pr-action"]':
+                              createdForUser: '${ownerEmail}'
+                              kind: 'action-callback'
+                          'tasks_for == "cron"':
+                              kind: cron-task
+
+                  routes:
+                      $flatten:
+                          - checks
+                          - $switch:
+                                'tasks_for == "github-push"':
+                                    - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"
+                                    - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision"
+                                'tasks_for == "action"':
+                                    - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.actions.${ownTaskId}"
+                                'tasks_for == "cron"':
+                                    - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision-${cron.job_name}"
+                                    - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision-${cron.job_name}"
+                                    # list each cron task on this revision, so actions can find them
+                                    - 'index.${trustDomain}.v2.${project}.revision.${head_sha}.cron.${ownTaskId}'
+                                $default: []
+
+                  scopes:
+                      $switch:
+                          'tasks_for in ["github-push"]':
+                              - 'assume:repo:${repoUrl[8:]}:branch:${short_head_ref}'
+                          'isPullRequest':
+                              - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${tasks_for[7:]}'
+                          'tasks_for == "action"':
+                              - 'assume:repo:${repoUrl[8:]}:action:${action.action_perm}'
+                          'tasks_for == "pr-action"':
+                              - 'assume:repo:${repoUrl[8:]}:pr-action:${action.action_perm}'
+                          $default:
+                              - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
+
+                  dependencies: []
+                  requires: all-completed
+
+                  priority:
+                      $switch:
+                          'tasks_for == "cron"': low
+                          'tasks_for == "github-push"|| isPullRequest': very-low
+                          $default: lowest  # tasks_for in ['action', 'pr-action']
+                  retries: 5
+
+                  payload:
+                      $let:
+                          normProject:
+                              $eval: 'join(split(project, "-"), "_")'
+                          normProjectUpper:
+                              $eval: 'uppercase(join(split(project, "-"), "_"))'
+                      in:
+                          env:
+                              # run-task uses these to check out the source; the inputs to
+                              # `taskgraph decision` are all on the command line.
+                              $merge:
+                                  - ${normProjectUpper}_BASE_REPOSITORY: '${baseRepoUrl}'
+                                    ${normProjectUpper}_BASE_REF: '${short_base_ref}'
+                                    ${normProjectUpper}_BASE_REV: '${base_sha}'
+                                    ${normProjectUpper}_HEAD_REPOSITORY: '${repoUrl}'
+                                    ${normProjectUpper}_HEAD_REF: '${short_head_ref}'
+                                    ${normProjectUpper}_HEAD_REV: '${head_sha}'
+                                    ${normProjectUpper}_REPOSITORY_TYPE: git
+                                    REPOSITORIES:
+                                        $json:
+                                            ${normProject}: ${normProject}
+                                  - $if: 'isPullRequest'
+                                    then:
+                                        ${normProjectUpper}_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
+                                  - $if: 'tasks_for in ["action", "pr-action"]'
+                                    then:
+                                        ACTION_TASK_GROUP_ID: '${action.taskGroupId}'  # taskGroupId of the target task
+                                        ACTION_TASK_ID: {$json: {$eval: 'taskId'}}  # taskId of the target task (JSON-encoded)
+                                        ACTION_INPUT: {$json: {$eval: 'input'}}
+                                        ACTION_CALLBACK: '${action.cb_name}'
+
+                          cache:
+                              "${trustDomain}-project-${project}-level-${level}-checkouts-sparse-v2": /builds/worker/checkouts
+
+                          features:
+                              taskclusterProxy: true
+
+                          image: mozillareleases/taskgraph:decision-v9.0.0@sha256:e56c7e5cd467c2ce497c344b358f68cc84a4f73f3422e507a97b397d4e617fbd
+                          maxRunTime: 1800
+
+                          command:
+                              - run-task
+                              - '--${normProject}-checkout=/builds/worker/checkouts/src'
+                              - '--'
+                              - bash
+                              - -cx
+                              - $let:
+                                    extraArgs: {$if: 'tasks_for == "cron"', then: '${cron.quoted_args}', else: ''}
+                                in:
+                                    $if: 'tasks_for in ["action", "pr-action"]'
+                                    then: >
+                                        cd /builds/worker/checkouts/src &&
+                                        ln -s /builds/worker/artifacts artifacts &&
+                                        taskgraph action-callback
+                                    else: >
+                                        cd /builds/worker/checkouts/src &&
+                                        ln -s /builds/worker/artifacts artifacts &&
+                                        taskgraph decision
+                                        --pushlog-id='0'
+                                        --pushdate='0'
+                                        --project='${project}'
+                                        --owner='${ownerEmail}'
+                                        --level='${level}'
+                                        --repository-type=git
+                                        --tasks-for='${tasks_for}'
+                                        --base-repository='${baseRepoUrl}'
+                                        --base-ref='${base_ref}'
+                                        --base-rev='${base_sha}'
+                                        --head-repository='${repoUrl}'
+                                        --head-ref='${head_ref}'
+                                        --head-rev='${head_sha}'
+                                        ${extraArgs}
+
+                          artifacts:
+                              'public':
+                                  type: 'directory'
+                                  path: '/builds/worker/artifacts'
+                                  expires: {$fromNow: '1 year'}
+                              'public/docker-contexts':
+                                  type: 'directory'
+                                  path: '/builds/worker/checkouts/src/docker-contexts'
+                                  # This needs to be at least the deadline of the
+                                  # decision task + the docker-image task deadlines.
+                                  # It is set to a week to allow for some time for
+                                  # debugging, but they are not useful long-term.
+                                  expires: {$fromNow: '7 day'}
+
+                          extra:
+                              $merge:
+                                  - $if: 'tasks_for in ["action", "pr-action"]'
+                                    then:
+                                        parent: '${action.taskGroupId}'
+                                        action:
+                                            name: '${action.name}'
+                                            context:
+                                                taskGroupId: '${action.taskGroupId}'
+                                                taskId: {$eval: 'taskId'}
+                                                input: {$eval: 'input'}
+                                                clientId: {$eval: 'clientId'}
+                                  - $if: 'tasks_for == "cron"'
+                                    then:
+                                        cron: {$json: {$eval: 'cron'}}
+                                  - tasks_for: '${tasks_for}'

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -1,0 +1,22 @@
+---
+trust-domain: "releng"
+task-priority: low
+
+taskgraph:
+  cached-task-prefix: "releng.v2.tooltool"
+  repositories:
+    tooltool:
+      name: "tooltool"
+
+workers:
+  aliases:
+    images:
+      provisioner: '{trust-domain}-{level}'
+      implementation: docker-worker
+      os: linux
+      worker-type: 'linux-gcp'
+    test:
+      provisioner: '{trust-domain}-t'
+      implementation: docker-worker
+      os: linux
+      worker-type: 'linux-gcp'

--- a/taskcluster/docker/skopeo/Dockerfile
+++ b/taskcluster/docker/skopeo/Dockerfile
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM debian:12-slim
+LABEL maintainer="Release Engineering <release@mozilla.com>"
+
+# %include-run-task
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -qq \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y jq zstd python3-minimal curl skopeo umoci \
+    && apt-get clean
+
+COPY push_image.sh /usr/local/bin/
+COPY policy.json /etc/containers/policy.json
+RUN chmod a+x /usr/local/bin/push_image.sh
+
+# Add worker user
+RUN mkdir -p /builds && \
+    groupadd -g 1000 -o worker && \
+    useradd -d /builds/worker -s /bin/bash -m worker -g 1000 -o -u 1000 && \
+    mkdir /builds/worker/artifacts && \
+    chown worker:worker /builds/worker/artifacts
+
+USER worker
+ENV SHELL=/bin/bash \
+    HOME=/builds/worker \
+    USER=worker
+
+WORKDIR /builds/worker
+# Set a default command useful for debugging
+CMD ["/bin/bash", "--login"]

--- a/taskcluster/docker/skopeo/policy.json
+++ b/taskcluster/docker/skopeo/policy.json
@@ -1,0 +1,14 @@
+{
+    "default": [{"type": "reject"}],
+    "transports": {
+        "oci": {
+            "": [{"type": "insecureAcceptAnything"}]
+        },
+        "docker-archive": {
+            "": [{"type": "insecureAcceptAnything"}]
+        },
+        "dir": {
+            "": [{"type": "insecureAcceptAnything"}]
+        }
+    }
+}

--- a/taskcluster/docker/skopeo/push_image.sh
+++ b/taskcluster/docker/skopeo/push_image.sh
@@ -1,0 +1,49 @@
+#!/bin/env bash
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+set -e -x
+
+test $NAME
+test $VERSION
+test $DOCKER_REPO
+test $DOCKER_TAG
+test $MOZ_FETCHES_DIR
+test $SECRET_URL
+test $TASKCLUSTER_ROOT_URL
+test $TASK_ID
+test $VCS_HEAD_REPOSITORY
+test $VCS_HEAD_REV
+
+echo "=== Generating dockercfg ==="
+install -m 600 /dev/null $HOME/.dockercfg
+# Note: If there's a scoping error, this will not fail, causing the skopeo copy command to fail
+curl $SECRET_URL | jq '.secret.docker.dockercfg' > $HOME/.dockercfg
+
+export REGISTRY_AUTH_FILE=$HOME/.dockercfg
+
+cd $MOZ_FETCHES_DIR
+unzstd image.tar.zst
+
+echo "=== Inserting version.json into image ==="
+# Create an OCI copy of image in order umoci can patch it
+skopeo copy docker-archive:image.tar oci:${NAME}:final
+
+cat > version.json <<EOF
+{
+    "commit": "${VCS_HEAD_REV}",
+    "version": "${VERSION}",
+    "source": "${VCS_HEAD_REPOSITORY}",
+    "build": "${TASKCLUSTER_ROOT_URL}/tasks/${TASK_ID}"
+}
+EOF
+
+umoci insert --image ${NAME}:final version.json /app/version.json
+
+echo "=== Pushing to docker hub ==="
+export DOCKER_ARCHIVE_TAG="${DOCKER_TAG}-${VERSION}-$(date +%Y%m%d%H%M%S)-${VCS_HEAD_REV}"
+
+
+skopeo copy oci:${NAME}:final docker://$DOCKER_REPO:$DOCKER_TAG
+skopeo copy oci:${NAME}:final docker://$DOCKER_REPO:$DOCKER_ARCHIVE_TAG

--- a/taskcluster/docker/tooltool-api/Dockerfile
+++ b/taskcluster/docker/tooltool-api/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.8
+
+RUN groupadd --gid 10001 app && \
+    useradd -g app --uid 10001 --shell /usr/sbin/nologin --create-home --home-dir /app app
+
+RUN apt-get update \
+ && ln -s /app/docker.d/healthcheck /bin/healthcheck
+
+ENV APP_SETTINGS /app/settings.py
+ENV FLASK_APP tooltool_api.flask:app
+ENV WEB_CONCURRENCY=3
+
+ENV PATH="/appenv/bin:${PATH}"
+
+# %include api
+COPY topsrcdir/api/ /app
+
+RUN mkdir /appenv \
+ && chown -R app:app /app /appenv
+
+USER app
+WORKDIR /app
+
+ARG FRONTEND_CONFIG
+RUN cp /app/src/tooltool_api/static/${FRONTEND_CONFIG} /app/src/tooltool_api/static/config.mjs
+
+RUN python -m venv /appenv \
+ && /appenv/bin/pip install --upgrade pip \
+ && /appenv/bin/pip install -r requirements/base.txt \
+ && /appenv/bin/pip install -e .
+
+CMD ["/app/docker.d/run.sh"]

--- a/taskcluster/docker/tox/Dockerfile
+++ b/taskcluster/docker/tox/Dockerfile
@@ -1,0 +1,24 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+LABEL maintainer="Mozilla Release Engineering <release+docker@mozilla.com>"
+
+# Add worker user
+RUN mkdir -p /builds && \
+    adduser --home /builds/worker --shell /bin/sh --disabled-password --gecos '' worker && \
+    mkdir /builds/worker/artifacts && \
+    chown worker:worker /builds/worker/artifacts
+
+# %include-run-task
+
+ENV HOME=/builds/worker \
+    PATH=/builds/worker/.local/bin:$PATH
+
+RUN apt-get update && apt-get install -y jq && pip install tox
+ARG SETUP_COMMAND
+RUN eval $SETUP_COMMAND
+
+VOLUME /builds/worker/checkouts
+VOLUME /builds/worker/.cache
+
+# Set a default command useful for debugging
+CMD ["/bin/sh"]

--- a/taskcluster/kinds/docker-image/kind.yml
+++ b/taskcluster/kinds/docker-image/kind.yml
@@ -1,0 +1,66 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.docker_image:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+tasks:
+    client-tox-py38:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.8
+            SETUP_COMMAND: 'apt-get update && apt-get install -y zip xz-utils build-essential libssl-dev libffi-dev python3-dev'
+    client-tox-py39:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.9
+            SETUP_COMMAND: 'apt-get update && apt-get install -y zip xz-utils build-essential libssl-dev libffi-dev python3-dev'
+    client-tox-py310:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.10
+            SETUP_COMMAND: 'apt-get update && apt-get install -y zip xz-utils build-essential libssl-dev libffi-dev python3-dev'
+    client-tox-py311:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.11
+            SETUP_COMMAND: 'apt-get update && apt-get install -y zip xz-utils build-essential libssl-dev libffi-dev python3-dev'
+    client-tox-py312:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.12
+            SETUP_COMMAND: 'apt-get update && apt-get install -y zip xz-utils build-essential libssl-dev libffi-dev python3-dev'
+    api-tox-py38:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.8
+            SETUP_COMMAND: 'apt-get update && apt-get install -y postgresql'
+    api-tox-py39:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.9
+            SETUP_COMMAND: 'apt-get update && apt-get install -y postgresql'
+    api-tox-py310:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.10
+            SETUP_COMMAND: 'apt-get update && apt-get install -y postgresql'
+    api-tox-py311:
+        definition: tox
+        args:
+            BASE_IMAGE: python:3.11
+            SETUP_COMMAND: 'apt-get update && apt-get install -y postgresql'
+    tooltool-api-staging:
+        definition: tooltool-api
+        args:
+            FRONTEND_CONFIG: config.stage.mjs
+    tooltool-api-production:
+        definition: tooltool-api
+        args:
+            FRONTEND_CONFIG: config.prod.mjs
+    skopeo: {}

--- a/taskcluster/kinds/pr/kind.yml
+++ b/taskcluster/kinds/pr/kind.yml
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+  - tooltool_taskgraph.transforms.complete
+  - taskgraph.transforms.task
+
+kind-dependencies:
+    - tox
+    - docker-image
+
+tasks:
+    complete:
+        description: PR Summary Task
+        run-on-tasks-for: [github-pull-request]
+        worker-type: succeed

--- a/taskcluster/kinds/push-image/kind.yml
+++ b/taskcluster/kinds/push-image/kind.yml
@@ -1,0 +1,49 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+transforms:
+  - tooltool_taskgraph.transforms.push_image
+
+kind-dependencies:
+  - docker-image
+
+task-defaults:
+  description: push tooltool_api docker image to docker hub
+  worker-type: images
+  worker:
+    max-run-time: 1800
+    env:
+      SECRET_URL: 'http://taskcluster/secrets/v1/secret/project/releng/tooltool/deploy'
+      DOCKER_REPO: mozilla/releng-tooltool
+    docker-image: {in-tree: skopeo}
+  scopes:
+    - 'secrets:get:project/releng/tooltool/deploy'
+  run:
+    using: run-task
+    command: 'push_image.sh'
+    checkout: false
+  run-on-tasks-for: [github-push]
+  fetches:
+    parent-image:
+      - artifact: image.tar.zst
+        extract: false
+
+tasks:
+  staging:
+    run-on-git-branches: [^staging$]
+    worker:
+      env:
+        NAME: tooltool-api-staging
+        DOCKER_TAG: staging
+    dependencies:
+      parent-image: build-docker-image-tooltool-api-staging
+
+  production:
+    run-on-git-branches: [^production$]
+    worker:
+      env:
+        NAME: tooltool-api-staging
+        DOCKER_TAG: production
+    dependencies:
+      parent-image: build-docker-image-tooltool-api-production

--- a/taskcluster/kinds/tox/api.yml
+++ b/taskcluster/kinds/tox/api.yml
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+task-defaults:
+  description: test the tooltool api
+
+api-py38:
+  worker:
+    docker-image: {in-tree: api-tox-py38}
+  run:
+    command: tox -e tooltool_api-py38
+api-py39:
+  worker:
+    docker-image: {in-tree: api-tox-py39}
+  run:
+    command: tox -e tooltool_api-py39
+api-py310:
+  worker:
+    docker-image: {in-tree: api-tox-py310}
+  run:
+    command: tox -e tooltool_api-py310
+api-py311:
+  worker:
+    docker-image: {in-tree: api-tox-py311}
+  run:
+    command: tox -e tooltool_api-py311

--- a/taskcluster/kinds/tox/client.yml
+++ b/taskcluster/kinds/tox/client.yml
@@ -1,0 +1,32 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+task-defaults:
+  description: test the tooltool client
+
+client-py38:
+  worker:
+    docker-image: {in-tree: client-tox-py38}
+  run:
+    command: tox -e tooltool_client-py38
+client-py39:
+  worker:
+    docker-image: {in-tree: client-tox-py39}
+  run:
+    command: tox -e tooltool_client-py39
+client-py310:
+  worker:
+    docker-image: {in-tree: client-tox-py310}
+  run:
+    command: tox -e tooltool_client-py310
+client-py311:
+  worker:
+    docker-image: {in-tree: client-tox-py311}
+  run:
+    command: tox -e tooltool_client-py311
+client-py312:
+  worker:
+    docker-image: {in-tree: client-tox-py312}
+  run:
+    command: tox -e tooltool_client-py312

--- a/taskcluster/kinds/tox/kind.yml
+++ b/taskcluster/kinds/tox/kind.yml
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+transforms:
+    - tooltool_taskgraph.transforms.codecov
+
+
+task-defaults:
+  worker-type: test
+  worker:
+    max-run-time: 1800
+    env:
+      SECRET_URL: 'http://taskcluster/secrets/v1/secret/project/releng/tooltool/ci'
+  run:
+    using: run-task
+    checkout:
+      tooltool: {}
+    cwd: '{checkout}'
+  scopes:
+    - 'secrets:get:project/releng/tooltool/ci'
+
+tasks-from:
+  - api.yml
+  - client.yml

--- a/taskcluster/tooltool_taskgraph/transforms/codecov.py
+++ b/taskcluster/tooltool_taskgraph/transforms/codecov.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
+from taskgraph.transforms.base import TransformSequence
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def set_coverage_env(config, tasks):
+    for task in tasks:
+        env = task.setdefault("worker", {}).setdefault("env", {})
+        env["CI_HEAD_REV"] = config.params["head_rev"]
+        env["CI_PR_NUMBER"] = os.environ.get("TOOLTOOL_PULL_REQUEST_NUMBER", "")
+        yield task
+
+
+@transforms.add
+def get_secret(config, tasks):
+    for task in tasks:
+        secret = 'export CODECOV_TOKEN=$(wget -qO- $SECRET_URL | jq -r \'.["secret"]["codecov"]["token"]\')'
+        task["run"][
+            "command"
+        ] = f"set +x && {secret} && set -x && {task['run']['command']}"
+        yield task

--- a/taskcluster/tooltool_taskgraph/transforms/complete.py
+++ b/taskcluster/tooltool_taskgraph/transforms/complete.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Add soft-dependencies on all kind-dependencies
+"""
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_dependencies(config, tasks):
+    for task in tasks:
+        task.setdefault("soft-dependencies", [])
+        task["soft-dependencies"].extend(
+            dep_task.label
+            for dep_task in config.kind_dependencies_tasks.values()
+        )
+        yield task

--- a/taskcluster/tooltool_taskgraph/transforms/push_image.py
+++ b/taskcluster/tooltool_taskgraph/transforms/push_image.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.parameters import get_version
+from taskgraph.transforms.base import TransformSequence
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def set_push_image_env(config, tasks):
+    for task in tasks:
+        env = task.setdefault("worker", {}).setdefault("env", {})
+        env["VERSION"] = get_version("api")
+        env["VCS_HEAD_REV"] = config.params["head_rev"]
+        env["VCS_HEAD_REPOSITORY"] = config.params["head_repository"]
+        yield task


### PR DESCRIPTION
This adds the following task kinds:
- docker-image: build images for other tasks (tox and skopeo) as well as
  images for the tooltool API/UI.
- tox: runs tests on various python version for the tooltool client and
  server
- push-image: injects version.json in the tooltool-api docker images,
  and pushes them to docker hub