### PR TITLE
ci: run tasks on push to master/staging/production

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -99,7 +99,7 @@ tasks:
           in:
               $if: >
                   tasks_for in ["action", "pr-action", "cron"]
-                  || (tasks_for == "github-push" && short_head_ref == "main")
+                  || (tasks_for == "github-push" && short_head_ref in ["main", "master", "staging", "production"])
                   || (isPullRequest && pullRequestAction in ["opened", "reopened", "synchronize"])
               then:
                   taskId: {$if: 'tasks_for != "action" && tasks_for != "pr-action"', then: '${ownTaskId}'}


### PR DESCRIPTION
The default .taskcluster.yml template was too restrictive here and I didn't catch that in #1186.