### PR TITLE
Work around a route naming mismatch for swagger due to a connexion bug

### DIFF
--- a/api/src/tooltool_api/api.yml
+++ b/api/src/tooltool_api/api.yml
@@ -3,6 +3,7 @@ swagger: "2.0"
 info:
   version: "1.0.0"
   title: "ToolTool"
+basePath: /api
 consumes:
  - application/json
 produces:

--- a/api/src/tooltool_api/lib/api.py
+++ b/api/src/tooltool_api/lib/api.py
@@ -60,6 +60,12 @@ class Api:
             pass_context_arg_name=pass_context_arg_name,
             options=options,
         )
+
+        # Work around a connexion 2 bug to keep the api served at `/` despite it
+        # having to have a baseUrl different from `/` for the internal route names
+        # to match between what connexion registers and what it expects later
+        api.blueprint.url_prefix = ""
+
         self.swagger_url = api.options.openapi_console_ui_path
         app.register_blueprint(api.blueprint)
 

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -221,3 +221,8 @@ def s3(aws_credentials):
 @pytest.fixture
 def bucket(s3):
     s3.create_bucket(Bucket="bucket")
+
+
+def test_swagger(real_client):
+    resp = real_client.get("/apidocs/")
+    assert resp.status_code == 200


### PR DESCRIPTION
This fixes a regression from 56b0650d4561cc2b5c9034f224016e23df69ac4e where connexion got updated from 2.14.2 to 2.15.1, picking up https://github.com/spec-first/connexion/pull/1992

That PR introduced a bug where connexion would register the swagger json route as `/./openapi_json` through flask, and expect to find it back as `.openapi_json` later on.

The issue lies in the `or "/"` addition [here](https://github.com/spec-first/connexion/pull/1992/files#diff-c8fea6c480f7f7a8cf1b08f6df00f794f8ec28112e2c5c8d867989b6f5017bb2R39) When we declare the api with a base url that's missing or is `/`, it gets normalized through `canonical_base_path` which rstrips `/`. We end up with `self.base_path = ""` in both cases. It then ends up creating the blueprint with `endpoint` being `"/"` instead of `""` like it was before that commit. That makes flask register the route as `/./openapi_json` (`{blueprint.name}.{route.replace('.', '_')}`).

When connexion tries to render the swagger UI, it tries to find that route back by doing what flask does internally when naming blueprint routes.

```py
openapi_json_route_name = "{blueprint}.{prefix}_openapi_json"
escaped = flask_utils.flaskify_endpoint(self.base_path)
openapi_json_route_name = openapi_json_route_name.format(
    blueprint=escaped, prefix=escaped
)
```

But here it fails to make an empty base_path fallback to `/` and so it ends up with a route name of `.openapi_json` instead of `/./openapi_json`.

By forcing the base path to be something that doesn't end up as an empty string in the code, we avoid the mismatch in the route naming (both route names ending as `/api./openapi_json`). To continue serving the API at the root though, we have to override the blueprint's url_prefix to an empty string.

Fixes #1456