### PR TITLE
Don't try to use the codecov secret in untrusted PRs

### DIFF
--- a/taskcluster/kinds/tox/kind.yml
+++ b/taskcluster/kinds/tox/kind.yml
@@ -11,15 +11,11 @@ task-defaults:
   worker-type: test
   worker:
     max-run-time: 1800
-    env:
-      SECRET_URL: 'http://taskcluster/secrets/v1/secret/project/releng/tooltool/ci'
   run:
     using: run-task
     checkout:
       tooltool: {}
     cwd: '{{checkout}}'
-  scopes:
-    - 'secrets:get:project/releng/tooltool/ci'
 
 tasks-from:
   - api.yml

--- a/taskcluster/tooltool_taskgraph/transforms/codecov.py
+++ b/taskcluster/tooltool_taskgraph/transforms/codecov.py
@@ -9,6 +9,9 @@ from taskgraph.transforms.base import TransformSequence
 
 transforms = TransformSequence()
 
+SECRET_NAME = "project/releng/tooltool/ci"
+SECRET_URL = f"http://taskcluster/secrets/v1/secret/{SECRET_NAME}"
+
 
 @transforms.add
 def set_coverage_env(config, tasks):
@@ -21,7 +24,13 @@ def set_coverage_env(config, tasks):
 
 @transforms.add
 def get_secret(config, tasks):
+    if config.params["tasks_for"] == "github-pull-request-untrusted":
+        yield from tasks
+        return
+
     for task in tasks:
+        task["worker"]["env"]["SECRET_URL"] = SECRET_URL
+        task.setdefault("scopes", []).append(f"secrets:get:{SECRET_NAME}")
         secret = 'export CODECOV_TOKEN=$(wget -qO- $SECRET_URL | jq -r \'.["secret"]["codecov"]["token"]\')'
         task["run"][
             "command"


### PR DESCRIPTION
I would've kept the secret url/scope in the yml but decided against it to keep both in the same place since we cannot `by-tasks-for` for lists.