### PR TITLE
Also run pr-complete on untrusted PRs

### DIFF
--- a/taskcluster/kinds/pr/kind.yml
+++ b/taskcluster/kinds/pr/kind.yml
@@ -15,5 +15,5 @@ kind-dependencies:
 tasks:
     complete:
         description: PR Summary Task
-        run-on-tasks-for: [github-pull-request]
+        run-on-tasks-for: [github-pull-request, github-pull-request-untrusted]
         worker-type: succeed


### PR DESCRIPTION
We rely on this for PRs to get merged and it was not running on github-pull-request-untrusted